### PR TITLE
Add requirements section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ vim-textobj-entire provides two text objects:
 
 See also [the reference manual](https://github.com/kana/vim-textobj-entire/blob/master/doc/textobj-entire.txt) for more details.
 
-
+You need to install the vim-textobj-user plugin to make vim-textobj-entire plugin work: https://github.com/kana/vim-textobj-user
 
 
 <!-- vim: set expandtab shiftwidth=4 softtabstop=4 textwidth=78 : -->


### PR DESCRIPTION
I had this issue today. I installed this library and got an error because I didn't have installed `vim-textobj-user`. I checked the `README` and a bit of the reference manual but didn't find anything fast. A few users have this issue too as mentioned on #14.

This PR adds a section at the bottom of the readme file that includes a reference to `vim-textobj-user` so users are less likely to have this issue in the future.